### PR TITLE
fix: remove tsconfigRootDir configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,8 +174,7 @@ module.exports = {
     ecmaVersion: 2021,
     impliedStrict: true,
     project: './tsconfig.json',
-    sourceType: 'module',
-    tsconfigRootDir: __dirname
+    sourceType: 'module'
   },
   plugins: ['no-only-tests', 'import', 'prefer-arrow', '@typescript-eslint'],
   rules,


### PR DESCRIPTION
it is making eslint to search for the config files
inside the node_modules eslint-config-ts-mailonline