### PR TITLE
feat: 🎸 add consistent type imports rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,12 @@ const rules = {
     }
   ],
   '@typescript-eslint/consistent-type-assertions': 'error',
+  '@typescript-eslint/consistent-type-imports': [
+    'error',
+    {
+      fixStyle: 'inline-type-imports'
+    }
+  ],
   '@typescript-eslint/naming-convention': [
     'error',
     {


### PR DESCRIPTION
Opening this after a comment left by @svt-ivanov in a PR which includes [this link](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports).

Here's a [link to the documentation for this rule](https://typescript-eslint.io/rules/consistent-type-imports/).

**Important**: I had to use `fixStyle: 'inline-type-imports'` because the default behaviour clashes [with the no-duplicate-imports rule](https://github.com/typescript-eslint/typescript-eslint/issues/2315) because it creates two imports, one for types and one for non-types:

```typescript
import type {Foo} from 'foobar';
import {Bar} from 'foobar';
```

With `inline-type-imports` it will do this instead:

```typescript
import {Bar, type Foo} from 'foobar';
```

However this is supported only in TS from v4.5 so some older projects might have issues with this update.