### PR TITLE
feat: 🎸 remove parameter-properties rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ const rules = {
     }
   ],
   '@typescript-eslint/no-unused-vars': 'off',
-  '@typescript-eslint/parameter-properties': 'error',
   '@typescript-eslint/prefer-for-of': 'error',
   '@typescript-eslint/promise-function-async': 'error',
   '@typescript-eslint/restrict-plus-operands': 'error',


### PR DESCRIPTION
The [parameter-properties ](https://typescript-eslint.io/rules/parameter-properties) rule at the moment disallows declaring class properties in the constructor. So instead of something like this:

```typescript
class SecurityError extends Error {
  constructor(public readonly message: string, public readonly status: 401 | 403 = 401) {
    super(message);
    Object.setPrototypeOf(this, SecurityError.prototype);
  }
}
```

You have to do this instead:

```typescript
class SecurityError extends Error {
  public readonly message: string;
  public readonly status: 401 | 403;

  constructor(message: string, status: 401 | 403 = 401) {
    super(message);
    this.message = message;
    this.status = status;
    Object.setPrototypeOf(this, SecurityError.prototype);
  }
}
```

I.e. nearly duplicating the number of lines for no reason whatsoever IMO.

The reasoning provided in the rule docs is very weak IMO, basically to cater for people new to TS?: `TypeScript includes a "parameter properties" shorthand for declaring a class constructor parameter and class property in one location. Parameter properties can be confusing to those new to TypeScript as they are less explicit than other ways of declaring and initializing class members.`
