### PR TITLE
MOL-32262: enable '@typescript-eslint/no-unused-vars' rule to error

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const rules = {
       allowDestructuring: true
     }
   ],
-  '@typescript-eslint/no-unused-vars': 'off',
+  '@typescript-eslint/no-unused-vars': 'error',
   '@typescript-eslint/prefer-for-of': 'error',
   '@typescript-eslint/promise-function-async': 'error',
   '@typescript-eslint/restrict-plus-operands': 'error',


### PR DESCRIPTION
https://anm508a.atlassian.net/browse/MOL-32262

Issues: MOL-32262